### PR TITLE
챌린지 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,6 @@
 def javaProjects = [
         project(':month-app'),
-        project(':month-domain'),
-        project(':month-common')
+        project(':month-domain')
 ]
 
 buildscript {

--- a/http/challenge.http
+++ b/http/challenge.http
@@ -1,0 +1,22 @@
+### 챌린지 생성 API
+POST {{host}}/api/v1/challenge
+Content-Type: application/json
+Authorization: Bearer {{AUTHORIZATION}}
+
+{
+  "name": "운동하는 챌린지",
+  "description" : "매일 운동하는 챌린지입니다.",
+  "startDateTime": "2020-09-01T10:00:00",
+  "endDateTime":  "2020-10-01T00:00:00",
+  "certifyType": "PICTURE"
+}
+
+> {%
+client.global.set("CHALLENGE_UUID", response.body["data"]["challengeUuid"])
+ %}
+
+### 챌린지 정보 불러오기 API
+GET {{host}}/api/v1/challenge?uuid={{CHALLENGE_UUID}}
+Authorization: Bearer {{AUTHORIZATION}}
+
+###

--- a/http/challenge.http
+++ b/http/challenge.http
@@ -19,4 +19,8 @@ client.global.set("CHALLENGE_UUID", response.body["data"]["challengeUuid"])
 GET {{host}}/api/v1/challenge?uuid={{CHALLENGE_UUID}}
 Authorization: Bearer {{AUTHORIZATION}}
 
+### 내가 참가하고 있는 챌린지 리스트 정보를 불러오는 API
+GET {{host}}/api/v1/challenge/my
+Authorization: Bearer {{AUTHORIZATION}}
+
 ###

--- a/http/challenge.http
+++ b/http/challenge.http
@@ -23,4 +23,25 @@ Authorization: Bearer {{AUTHORIZATION}}
 GET {{host}}/api/v1/challenge/my
 Authorization: Bearer {{AUTHORIZATION}}
 
+### 초대키를 발급하는 API
+PUT {{host}}/api/v1/challenge/inviteKey
+Content-Type: application/json
+Authorization: Bearer {{AUTHORIZATION}}
+
+{
+  "challengeUuid": "{{CHALLENGE_UUID}}"
+}
+> {%
+client.global.set("CHALLENGE_INVITATION_KEY", response.body["data"])
+ %}
+
+### 초대키를 통해 챌린지에 참가하는 API
+PUT {{host}}/api/v1/challenge/invite
+Content-Type: application/json
+Authorization: Bearer {{AUTHORIZATION}}
+
+{
+  "invitationKey": "{{CHALLENGE_INVITATION_KEY}}"
+}
+
 ###

--- a/month-app/build.gradle
+++ b/month-app/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     implementation project(':month-domain')
-    implementation project(':month-common')
 
     implementation 'org.springframework.boot:spring-boot-configuration-processor'
     implementation 'org.springframework.boot:spring-boot-starter-web'

--- a/month-app/src/main/java/com/month/config/InitBinderConfig.java
+++ b/month-app/src/main/java/com/month/config/InitBinderConfig.java
@@ -1,0 +1,15 @@
+package com.month.config;
+
+import org.springframework.web.bind.WebDataBinder;
+import org.springframework.web.bind.annotation.InitBinder;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class InitBinderConfig {
+
+	@InitBinder
+	public void initBinder(WebDataBinder binder) {
+		binder.initDirectFieldAccess();
+	}
+
+}

--- a/month-app/src/main/java/com/month/controller/auth/AuthController.java
+++ b/month-app/src/main/java/com/month/controller/auth/AuthController.java
@@ -5,6 +5,7 @@ import com.month.service.auth.AuthService;
 import com.month.service.auth.dto.request.AuthRequest;
 import com.month.type.session.MemberSession;
 import com.month.utils.HeaderUtils;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.session.SessionRepository;
@@ -27,6 +28,7 @@ public class AuthController {
 
 	private final SessionRepository sessionRepository;
 
+	@ApiOperation("회원가입 or 로그인을 진행하는 API")
 	@PostMapping("/api/v1/auth")
 	public ApiResponse<String> handleAuthentication(@Valid @RequestBody AuthRequest request) {
 		Long memberId = authService.handleAuthentication(request);
@@ -34,6 +36,7 @@ public class AuthController {
 		return ApiResponse.of(httpSession.getId());
 	}
 
+	@ApiOperation("로그아웃을 진행하는 API")
 	@PostMapping("/api/v1/logout")
 	public ApiResponse<String> handleLogout(@RequestHeader HttpHeaders httpHeaders) {
 		String header = httpHeaders.getFirst(HttpHeaders.AUTHORIZATION);
@@ -41,6 +44,5 @@ public class AuthController {
 		sessionRepository.delete(header.split(HeaderUtils.BEARER_TOKEN)[1]);
 		return ApiResponse.OK;
 	}
-
 
 }

--- a/month-app/src/main/java/com/month/controller/challenge/ChallengeController.java
+++ b/month-app/src/main/java/com/month/controller/challenge/ChallengeController.java
@@ -3,9 +3,12 @@ package com.month.controller.challenge;
 import com.month.config.resolver.LoginMember;
 import com.month.controller.ApiResponse;
 import com.month.service.challenge.ChallengeService;
+import com.month.service.challenge.dto.request.ChallengeCreateInvitationKeyRequest;
 import com.month.service.challenge.dto.request.ChallengeCreateRequest;
+import com.month.service.challenge.dto.request.ChallengeInviteRequest;
 import com.month.service.challenge.dto.request.ChallengeRetrieveRequest;
 import com.month.service.challenge.dto.response.ChallengeInfoResponse;
+import com.month.service.challenge.dto.response.ChallengeSimpleInfoResponse;
 import com.month.type.session.MemberSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -20,18 +23,33 @@ public class ChallengeController {
 	private final ChallengeService challengeService;
 
 	@PostMapping("/api/v1/challenge")
-	public ApiResponse<ChallengeInfoResponse> createNewChallenge(@Valid @RequestBody ChallengeCreateRequest request, @LoginMember MemberSession memberSession) {
+	public ApiResponse<ChallengeSimpleInfoResponse> createNewChallenge(@Valid @RequestBody ChallengeCreateRequest request, @LoginMember MemberSession memberSession) {
 		return ApiResponse.of(challengeService.createNewChallenge(request, memberSession.getMemberId()));
 	}
 
 	@GetMapping("/api/v1/challenge")
 	public ApiResponse<ChallengeInfoResponse> getChallengeInfo(@Valid ChallengeRetrieveRequest request, @LoginMember MemberSession memberSession) {
-		return ApiResponse.of(challengeService.getChallengeInfo(request, memberSession.getMemberId()));
+		return ApiResponse.of(challengeService.getDetailChallengeInfo(request, memberSession.getMemberId()));
 	}
 
 	@GetMapping("/api/v1/challenge/my")
-	public ApiResponse<List<ChallengeInfoResponse>> getMyChallengesInfo(@LoginMember MemberSession memberSession) {
+	public ApiResponse<List<ChallengeSimpleInfoResponse>> getMyChallengesInfo(@LoginMember MemberSession memberSession) {
 		return ApiResponse.of(challengeService.getMyChallengeInfo(memberSession.getMemberId()));
+	}
+
+	@PutMapping("/api/v1/challenge/inviteKey")
+	public ApiResponse<String> creatChallengeInviteKey(@Valid @RequestBody ChallengeCreateInvitationKeyRequest request, @LoginMember MemberSession memberSession) {
+		return ApiResponse.of(challengeService.createInvitationKey(request, memberSession.getMemberId()));
+	}
+
+	@PutMapping("/api/v1/challenge/invite")
+	public ApiResponse<ChallengeSimpleInfoResponse> inviteMemberByInvitationKey(@Valid @RequestBody ChallengeInviteRequest request, @LoginMember MemberSession memberSession) {
+		return ApiResponse.of(challengeService.inviteNewMemberWithInvitationKey(request, memberSession.getMemberId()));
+	}
+
+	@GetMapping("/api/v1/challenge/invite")
+	public ApiResponse<ChallengeSimpleInfoResponse> getInviteChallengeInfo(@Valid @RequestParam String invitationKey) {
+		return ApiResponse.of(challengeService.getSimpleChallengeInfoByInvitationKey(invitationKey));
 	}
 
 }

--- a/month-app/src/main/java/com/month/controller/challenge/ChallengeController.java
+++ b/month-app/src/main/java/com/month/controller/challenge/ChallengeController.java
@@ -10,6 +10,7 @@ import com.month.service.challenge.dto.request.ChallengeRetrieveRequest;
 import com.month.service.challenge.dto.response.ChallengeInfoResponse;
 import com.month.service.challenge.dto.response.ChallengeSimpleInfoResponse;
 import com.month.type.session.MemberSession;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -22,31 +23,37 @@ public class ChallengeController {
 
 	private final ChallengeService challengeService;
 
+	@ApiOperation("새로운 챌린지를 생성하는 API")
 	@PostMapping("/api/v1/challenge")
 	public ApiResponse<ChallengeSimpleInfoResponse> createNewChallenge(@Valid @RequestBody ChallengeCreateRequest request, @LoginMember MemberSession memberSession) {
 		return ApiResponse.of(challengeService.createNewChallenge(request, memberSession.getMemberId()));
 	}
 
+	@ApiOperation("특정 챌린지의 상세정보를 불러오는 API")
 	@GetMapping("/api/v1/challenge")
 	public ApiResponse<ChallengeInfoResponse> getChallengeInfo(@Valid ChallengeRetrieveRequest request, @LoginMember MemberSession memberSession) {
 		return ApiResponse.of(challengeService.getDetailChallengeInfo(request, memberSession.getMemberId()));
 	}
 
+	@ApiOperation("내가 포함하고 있는 챌린지 리스트를 불러오는 API")
 	@GetMapping("/api/v1/challenge/my")
 	public ApiResponse<List<ChallengeSimpleInfoResponse>> getMyChallengesInfo(@LoginMember MemberSession memberSession) {
 		return ApiResponse.of(challengeService.getMyChallengeInfo(memberSession.getMemberId()));
 	}
 
+	@ApiOperation("챌린지의 새로운 초대키를 발급하는 API")
 	@PutMapping("/api/v1/challenge/inviteKey")
 	public ApiResponse<String> creatChallengeInviteKey(@Valid @RequestBody ChallengeCreateInvitationKeyRequest request, @LoginMember MemberSession memberSession) {
 		return ApiResponse.of(challengeService.createInvitationKey(request, memberSession.getMemberId()));
 	}
 
+	@ApiOperation("발급된 초대키를 통해 챌린지에 참가하는 API")
 	@PutMapping("/api/v1/challenge/invite")
 	public ApiResponse<ChallengeSimpleInfoResponse> inviteMemberByInvitationKey(@Valid @RequestBody ChallengeInviteRequest request, @LoginMember MemberSession memberSession) {
 		return ApiResponse.of(challengeService.inviteNewMemberWithInvitationKey(request, memberSession.getMemberId()));
 	}
 
+	@ApiOperation("초대키를 통해 챌린지의 간단한 정보를 가져오는 API")
 	@GetMapping("/api/v1/challenge/invite")
 	public ApiResponse<ChallengeSimpleInfoResponse> getInviteChallengeInfo(@Valid @RequestParam String invitationKey) {
 		return ApiResponse.of(challengeService.getSimpleChallengeInfoByInvitationKey(invitationKey));

--- a/month-app/src/main/java/com/month/controller/challenge/ChallengeController.java
+++ b/month-app/src/main/java/com/month/controller/challenge/ChallengeController.java
@@ -11,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -26,6 +27,11 @@ public class ChallengeController {
 	@GetMapping("/api/v1/challenge")
 	public ApiResponse<ChallengeInfoResponse> getChallengeInfo(@Valid ChallengeRetrieveRequest request, @LoginMember MemberSession memberSession) {
 		return ApiResponse.of(challengeService.getChallengeInfo(request, memberSession.getMemberId()));
+	}
+
+	@GetMapping("/api/v1/challenge/my")
+	public ApiResponse<List<ChallengeInfoResponse>> getMyChallengesInfo(@LoginMember MemberSession memberSession) {
+		return ApiResponse.of(challengeService.getMyChallengeInfo(memberSession.getMemberId()));
 	}
 
 }

--- a/month-app/src/main/java/com/month/controller/challenge/ChallengeController.java
+++ b/month-app/src/main/java/com/month/controller/challenge/ChallengeController.java
@@ -1,0 +1,31 @@
+package com.month.controller.challenge;
+
+import com.month.config.resolver.LoginMember;
+import com.month.controller.ApiResponse;
+import com.month.service.challenge.ChallengeService;
+import com.month.service.challenge.dto.request.ChallengeCreateRequest;
+import com.month.service.challenge.dto.request.ChallengeRetrieveRequest;
+import com.month.service.challenge.dto.response.ChallengeInfoResponse;
+import com.month.type.session.MemberSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import javax.validation.Valid;
+
+@RequiredArgsConstructor
+@RestController
+public class ChallengeController {
+
+	private final ChallengeService challengeService;
+
+	@PostMapping("/api/v1/challenge")
+	public ApiResponse<ChallengeInfoResponse> createNewChallenge(@Valid @RequestBody ChallengeCreateRequest request, @LoginMember MemberSession memberSession) {
+		return ApiResponse.of(challengeService.createNewChallenge(request, memberSession.getMemberId()));
+	}
+
+	@GetMapping("/api/v1/challenge")
+	public ApiResponse<ChallengeInfoResponse> getChallengeInfo(@Valid ChallengeRetrieveRequest request, @LoginMember MemberSession memberSession) {
+		return ApiResponse.of(challengeService.getChallengeInfo(request, memberSession.getMemberId()));
+	}
+
+}

--- a/month-app/src/main/java/com/month/controller/member/MemberController.java
+++ b/month-app/src/main/java/com/month/controller/member/MemberController.java
@@ -6,6 +6,7 @@ import com.month.service.member.MemberService;
 import com.month.service.member.dto.request.MemberUpdateInfoRequest;
 import com.month.service.member.dto.response.MemberInfoResponse;
 import com.month.type.session.MemberSession;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -20,11 +21,13 @@ public class MemberController {
 
 	private final MemberService memberService;
 
+	@ApiOperation("나의 회원 정보를 불러오는 API")
 	@GetMapping("/api/v1/member")
 	public ApiResponse<MemberInfoResponse> getMemberInfo(@LoginMember MemberSession memberSession) {
 		return ApiResponse.of(memberService.getMemberInfo(memberSession.getMemberId()));
 	}
 
+	@ApiOperation("나의 회원 정보를 수정하는 API")
 	@PutMapping("/api/v1/member")
 	public ApiResponse<MemberInfoResponse> updateMemberInfo(@Valid @RequestBody MemberUpdateInfoRequest request, @LoginMember MemberSession memberSession) {
 		return ApiResponse.of(memberService.updateMemberInfo(request, memberSession.getMemberId()));

--- a/month-app/src/main/java/com/month/service/challenge/ChallengeService.java
+++ b/month-app/src/main/java/com/month/service/challenge/ChallengeService.java
@@ -1,7 +1,9 @@
 package com.month.service.challenge;
 
+import com.month.config.resolver.LoginMember;
 import com.month.domain.challenge.Challenge;
 import com.month.domain.challenge.ChallengeRepository;
+import com.month.service.challenge.dto.request.ChallengeCreateInvitationKeyRequest;
 import com.month.service.challenge.dto.request.ChallengeCreateRequest;
 import com.month.service.challenge.dto.request.ChallengeRetrieveRequest;
 import com.month.service.challenge.dto.response.ChallengeInfoResponse;
@@ -38,6 +40,13 @@ public class ChallengeService {
 		return challenges.stream()
 				.map(ChallengeInfoResponse::of)
 				.collect(Collectors.toList());
+	}
+
+	@Transactional
+	public String createInvitationKey(ChallengeCreateInvitationKeyRequest request, Long memberId) {
+		Challenge challenge = ChallengeServiceUtils.findChallengeByUuid(challengeRepository, request.getChallengeUuid());
+		challenge.createNewInvitationKey(memberId);
+		return challenge.getInvitationKey();
 	}
 
 }

--- a/month-app/src/main/java/com/month/service/challenge/ChallengeService.java
+++ b/month-app/src/main/java/com/month/service/challenge/ChallengeService.java
@@ -1,0 +1,32 @@
+package com.month.service.challenge;
+
+import com.month.domain.challenge.Challenge;
+import com.month.domain.challenge.ChallengeRepository;
+import com.month.service.challenge.dto.request.ChallengeCreateRequest;
+import com.month.service.challenge.dto.request.ChallengeRetrieveRequest;
+import com.month.service.challenge.dto.response.ChallengeInfoResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class ChallengeService {
+
+	private final ChallengeRepository challengeRepository;
+
+	@Transactional
+	public ChallengeInfoResponse createNewChallenge(ChallengeCreateRequest request, Long memberId) {
+		Challenge challenge = request.toEntity();
+		challenge.addCreator(memberId);
+		return ChallengeInfoResponse.of(challengeRepository.save(challenge));
+	}
+
+	@Transactional(readOnly = true)
+	public ChallengeInfoResponse getChallengeInfo(ChallengeRetrieveRequest request, Long memberId) {
+		Challenge challenge = ChallengeServiceUtils.findChallengeByUuid(challengeRepository, request.getUuid());
+		challenge.validateMemberInChallenge(memberId);
+		return ChallengeInfoResponse.of(challenge);
+	}
+
+}

--- a/month-app/src/main/java/com/month/service/challenge/ChallengeService.java
+++ b/month-app/src/main/java/com/month/service/challenge/ChallengeService.java
@@ -9,6 +9,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @RequiredArgsConstructor
 @Service
 public class ChallengeService {
@@ -27,6 +30,14 @@ public class ChallengeService {
 		Challenge challenge = ChallengeServiceUtils.findChallengeByUuid(challengeRepository, request.getUuid());
 		challenge.validateMemberInChallenge(memberId);
 		return ChallengeInfoResponse.of(challenge);
+	}
+
+	@Transactional(readOnly = true)
+	public List<ChallengeInfoResponse> getMyChallengeInfo(Long memberId) {
+		List<Challenge> challenges = challengeRepository.findChallengesByMemberId(memberId);
+		return challenges.stream()
+				.map(ChallengeInfoResponse::of)
+				.collect(Collectors.toList());
 	}
 
 }

--- a/month-app/src/main/java/com/month/service/challenge/ChallengeServiceUtils.java
+++ b/month-app/src/main/java/com/month/service/challenge/ChallengeServiceUtils.java
@@ -1,0 +1,16 @@
+package com.month.service.challenge;
+
+import com.month.domain.challenge.Challenge;
+import com.month.domain.challenge.ChallengeRepository;
+
+final class ChallengeServiceUtils {
+
+	static Challenge findChallengeByUuid(ChallengeRepository challengeRepository, String uuid) {
+		Challenge challenge = challengeRepository.findChallengeByUuid(uuid);
+		if (challenge == null) {
+			throw new IllegalArgumentException(String.format("해당 uuid (%s) 를 가진 챌린지는 존재하지 않습니다.", uuid));
+		}
+		return challenge;
+	}
+
+}

--- a/month-app/src/main/java/com/month/service/challenge/ChallengeServiceUtils.java
+++ b/month-app/src/main/java/com/month/service/challenge/ChallengeServiceUtils.java
@@ -13,4 +13,12 @@ final class ChallengeServiceUtils {
 		return challenge;
 	}
 
+	static Challenge findChallengeByInvitationKey(ChallengeRepository challengeRepository, String invitationKey) {
+		Challenge challenge = challengeRepository.findChallengeByInvitationKey(invitationKey);
+		if (challenge == null) {
+			throw new IllegalArgumentException(String.format("해당 초대키 (%s) 를 가진 챌린지는 존재하지 않습니다.", invitationKey));
+		}
+		return challenge;
+	}
+
 }

--- a/month-app/src/main/java/com/month/service/challenge/dto/request/ChallengeCreateInvitationKeyRequest.java
+++ b/month-app/src/main/java/com/month/service/challenge/dto/request/ChallengeCreateInvitationKeyRequest.java
@@ -1,0 +1,20 @@
+package com.month.service.challenge.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChallengeCreateInvitationKeyRequest {
+
+	private String challengeUuid;
+
+	private ChallengeCreateInvitationKeyRequest(String challengeUuid) {
+		this.challengeUuid = challengeUuid;
+	}
+
+	public static ChallengeCreateInvitationKeyRequest testInstance(String challengeUuid) {
+		return new ChallengeCreateInvitationKeyRequest(challengeUuid);
+	}
+
+}

--- a/month-app/src/main/java/com/month/service/challenge/dto/request/ChallengeCreateRequest.java
+++ b/month-app/src/main/java/com/month/service/challenge/dto/request/ChallengeCreateRequest.java
@@ -1,0 +1,38 @@
+package com.month.service.challenge.dto.request;
+
+import com.month.domain.challenge.CertifyType;
+import com.month.domain.challenge.Challenge;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+public class ChallengeCreateRequest {
+
+	private String name;
+
+	private String description;
+
+	private LocalDateTime startDateTime;
+
+	private LocalDateTime endDateTime;
+
+	private CertifyType certifyType;
+
+	@Builder(builderClassName = "TestBuilder", builderMethodName = "testBuilder")
+	public ChallengeCreateRequest(String name, String description, LocalDateTime startDateTime, LocalDateTime endDateTime, CertifyType certifyType) {
+		this.name = name;
+		this.description = description;
+		this.startDateTime = startDateTime;
+		this.endDateTime = endDateTime;
+		this.certifyType = certifyType;
+	}
+
+	public Challenge toEntity() {
+		return Challenge.of(name, description, startDateTime, endDateTime, certifyType);
+	}
+
+}

--- a/month-app/src/main/java/com/month/service/challenge/dto/request/ChallengeInviteRequest.java
+++ b/month-app/src/main/java/com/month/service/challenge/dto/request/ChallengeInviteRequest.java
@@ -1,0 +1,20 @@
+package com.month.service.challenge.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChallengeInviteRequest {
+
+	private String invitationKey;
+
+	private ChallengeInviteRequest(String invitationKey) {
+		this.invitationKey = invitationKey;
+	}
+
+	public static ChallengeInviteRequest testInstance(String invitationKey) {
+		return new ChallengeInviteRequest(invitationKey);
+	}
+
+}

--- a/month-app/src/main/java/com/month/service/challenge/dto/request/ChallengeRetrieveRequest.java
+++ b/month-app/src/main/java/com/month/service/challenge/dto/request/ChallengeRetrieveRequest.java
@@ -1,0 +1,20 @@
+package com.month.service.challenge.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ChallengeRetrieveRequest {
+
+	private String uuid;
+
+	private ChallengeRetrieveRequest(String uuid) {
+		this.uuid = uuid;
+	}
+
+	public static ChallengeRetrieveRequest testInstance(String uuid) {
+		return new ChallengeRetrieveRequest(uuid);
+	}
+
+}

--- a/month-app/src/main/java/com/month/service/challenge/dto/response/ChallengeInfoResponse.java
+++ b/month-app/src/main/java/com/month/service/challenge/dto/response/ChallengeInfoResponse.java
@@ -2,11 +2,15 @@ package com.month.service.challenge.dto.response;
 
 import com.month.domain.challenge.CertifyType;
 import com.month.domain.challenge.Challenge;
+import com.month.domain.member.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
@@ -26,9 +30,16 @@ public class ChallengeInfoResponse {
 
 	private final CertifyType certifyType;
 
-	public static ChallengeInfoResponse of(Challenge challenge) {
-		return new ChallengeInfoResponse(challenge.getUuid(), challenge.getName(), challenge.getDescription(),
+	private final List<MemberInChallengeResponse> membersInChallenge = new ArrayList<>();
+
+	public static ChallengeInfoResponse of(Challenge challenge, List<Member> members) {
+		List<MemberInChallengeResponse> membersInfo = members.stream()
+				.map(MemberInChallengeResponse::of)
+				.collect(Collectors.toList());
+		ChallengeInfoResponse response = new ChallengeInfoResponse(challenge.getUuid(), challenge.getName(), challenge.getDescription(),
 				challenge.getMembersCount(), challenge.getStartDateTime(), challenge.getEndDateTime(), challenge.getCertifyType());
+		response.membersInChallenge.addAll(membersInfo);
+		return response;
 	}
 
 }

--- a/month-app/src/main/java/com/month/service/challenge/dto/response/ChallengeInfoResponse.java
+++ b/month-app/src/main/java/com/month/service/challenge/dto/response/ChallengeInfoResponse.java
@@ -1,0 +1,34 @@
+package com.month.service.challenge.dto.response;
+
+import com.month.domain.challenge.CertifyType;
+import com.month.domain.challenge.Challenge;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChallengeInfoResponse {
+
+	private final String challengeUuid;
+
+	private final String name;
+
+	private final String description;
+
+	private final int membersCount;
+
+	private final LocalDateTime startDateTime;
+
+	private final LocalDateTime endDateTime;
+
+	private final CertifyType certifyType;
+
+	public static ChallengeInfoResponse of(Challenge challenge) {
+		return new ChallengeInfoResponse(challenge.getUuid(), challenge.getName(), challenge.getDescription(),
+				challenge.getMembersCount(), challenge.getStartDateTime(), challenge.getEndDateTime(), challenge.getCertifyType());
+	}
+
+}

--- a/month-app/src/main/java/com/month/service/challenge/dto/response/ChallengeSimpleInfoResponse.java
+++ b/month-app/src/main/java/com/month/service/challenge/dto/response/ChallengeSimpleInfoResponse.java
@@ -1,0 +1,34 @@
+package com.month.service.challenge.dto.response;
+
+import com.month.domain.challenge.CertifyType;
+import com.month.domain.challenge.Challenge;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChallengeSimpleInfoResponse {
+
+	private final String challengeUuid;
+
+	private final String name;
+
+	private final String description;
+
+	private final LocalDateTime startDateTime;
+
+	private final LocalDateTime endDateTime;
+
+	private final int membersCount;
+
+	private final CertifyType certifyType;
+
+	public static ChallengeSimpleInfoResponse of(Challenge challenge) {
+		return new ChallengeSimpleInfoResponse(challenge.getUuid(), challenge.getName(), challenge.getDescription(),
+				challenge.getStartDateTime(), challenge.getEndDateTime(), challenge.getMembersCount(), challenge.getCertifyType());
+	}
+
+}

--- a/month-app/src/main/java/com/month/service/challenge/dto/response/MemberInChallengeResponse.java
+++ b/month-app/src/main/java/com/month/service/challenge/dto/response/MemberInChallengeResponse.java
@@ -1,0 +1,24 @@
+package com.month.service.challenge.dto.response;
+
+import com.month.domain.member.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberInChallengeResponse {
+
+	private final Long id;
+
+	private final String email;
+
+	private final String name;
+
+	private final String photoUrl;
+
+	public static MemberInChallengeResponse of(Member member) {
+		return new MemberInChallengeResponse(member.getId(), member.getEmail(), member.getName(), member.getPhotoUrl());
+	}
+
+}

--- a/month-app/src/test/java/com/month/service/MemberSetupTest.java
+++ b/month-app/src/test/java/com/month/service/MemberSetupTest.java
@@ -1,0 +1,29 @@
+package com.month.service;
+
+import com.month.domain.member.Member;
+import com.month.domain.member.MemberCreator;
+import com.month.domain.member.MemberRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public abstract class MemberSetupTest {
+
+	@Autowired
+	private MemberRepository memberRepository;
+
+	protected Long memberId;
+
+	@BeforeEach
+	void setUp() {
+		Member member = MemberCreator.create("will.seungho@gmail.com");
+		memberRepository.save(member);
+		memberId = member.getId();
+	}
+
+	protected void cleanup() {
+		memberRepository.deleteAll();
+	}
+	
+}

--- a/month-app/src/test/java/com/month/service/challenge/ChallengeServiceTest.java
+++ b/month-app/src/test/java/com/month/service/challenge/ChallengeServiceTest.java
@@ -4,8 +4,10 @@ import com.month.domain.challenge.*;
 import com.month.service.MemberSetupTest;
 import com.month.service.challenge.dto.request.ChallengeCreateInvitationKeyRequest;
 import com.month.service.challenge.dto.request.ChallengeCreateRequest;
+import com.month.service.challenge.dto.request.ChallengeInviteRequest;
 import com.month.service.challenge.dto.request.ChallengeRetrieveRequest;
 import com.month.service.challenge.dto.response.ChallengeInfoResponse;
+import com.month.service.challenge.dto.response.ChallengeSimpleInfoResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,8 +17,7 @@ import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.*;
 
 @SpringBootTest
 class ChallengeServiceTest extends MemberSetupTest {
@@ -108,7 +109,7 @@ class ChallengeServiceTest extends MemberSetupTest {
 		ChallengeRetrieveRequest request = ChallengeRetrieveRequest.testInstance(challenge.getUuid());
 
 		// when
-		ChallengeInfoResponse response = challengeService.getChallengeInfo(request, memberId);
+		ChallengeInfoResponse response = challengeService.getDetailChallengeInfo(request, memberId);
 
 		// then
 		assertThatChallengeInfoResponse(response, name, description, startDateTime, endDateTime, certifyType);
@@ -124,7 +125,7 @@ class ChallengeServiceTest extends MemberSetupTest {
 
 		// when & then
 		assertThatThrownBy(() -> {
-			challengeService.getChallengeInfo(request, memberId);
+			challengeService.getDetailChallengeInfo(request, memberId);
 		}).isInstanceOf(IllegalArgumentException.class);
 	}
 
@@ -138,7 +139,7 @@ class ChallengeServiceTest extends MemberSetupTest {
 		challengeRepository.saveAll(Arrays.asList(challenge1, challenge2));
 
 		// when
-		List<ChallengeInfoResponse> responses = challengeService.getMyChallengeInfo(memberId);
+		List<ChallengeSimpleInfoResponse> responses = challengeService.getMyChallengeInfo(memberId);
 
 		// then
 		assertThat(responses).hasSize(2);
@@ -149,7 +150,7 @@ class ChallengeServiceTest extends MemberSetupTest {
 	@Test
 	void 어떤_챌린지에도_참가하고_있지_않을때_나의_챌린지를_불러오면_빌_리스트가_반환된다() {
 		// when
-		List<ChallengeInfoResponse> responses = challengeService.getMyChallengeInfo(memberId);
+		List<ChallengeSimpleInfoResponse> responses = challengeService.getMyChallengeInfo(memberId);
 
 		// then
 		assertThat(responses).isEmpty();
@@ -172,6 +173,103 @@ class ChallengeServiceTest extends MemberSetupTest {
 		List<Challenge> challenges = challengeRepository.findAll();
 		assertThat(challenges).hasSize(1);
 		assertThat(challenges.get(0).getInvitationKey()).isNotNull();
+	}
+
+	@Test
+	void 챌린지에_참가중이지_않은_멤버는_초대키를_발급할_수없다() {
+		// given
+		Challenge challenge = ChallengeCreator.create("챌린지");
+		challengeRepository.save(challenge);
+
+		ChallengeCreateInvitationKeyRequest request = ChallengeCreateInvitationKeyRequest.testInstance(challenge.getUuid());
+
+		// when & then
+		assertThatThrownBy(() -> {
+			challengeService.createInvitationKey(request, memberId);
+		}).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void 초대키를_통해_새로운_멤버를_초대한다() {
+		// given
+		Challenge challenge = ChallengeCreator.create("챌린지");
+		challenge.addCreator(memberId);
+		challenge.createNewInvitationKey(memberId);
+		challengeRepository.save(challenge);
+
+		ChallengeInviteRequest request = ChallengeInviteRequest.testInstance(challenge.getInvitationKey());
+
+		// when
+		challengeService.inviteNewMemberWithInvitationKey(request, 2L);
+
+		// then
+		List<Challenge> challenges = challengeRepository.findAll();
+		assertThat(challenges).hasSize(1);
+		assertThat(challenges.get(0).getMembersCount()).isEqualTo(2);
+	}
+
+	@Test
+	void 초대키를_통해_멤버가_초대되면_참가자로_합류한다() {
+		// given
+		Challenge challenge = ChallengeCreator.create("챌린지");
+		challenge.addCreator(memberId);
+		challenge.createNewInvitationKey(memberId);
+		challengeRepository.save(challenge);
+
+		ChallengeInviteRequest request = ChallengeInviteRequest.testInstance(challenge.getInvitationKey());
+
+		// when
+		challengeService.inviteNewMemberWithInvitationKey(request, 2L);
+
+		// then
+		List<ChallengeMemberMapper> challengeMemberMappers = challengeMemberMapperRepository.findAll();
+		assertThat(challengeMemberMappers).hasSize(2);
+		assertThat(challengeMemberMappers.get(1).getMemberId()).isEqualTo(2L);
+		assertThat(challengeMemberMappers.get(1).getRole()).isEqualTo(ChallengeRole.PARTICIPATOR);
+	}
+
+	@Test
+	void 이미_챌린저에_있는_멤버는_초대될_수_없다() {
+		// given
+		Challenge challenge = ChallengeCreator.create("챌린지");
+		challenge.addCreator(memberId);
+		challenge.createNewInvitationKey(memberId);
+		challengeRepository.save(challenge);
+
+		ChallengeInviteRequest request = ChallengeInviteRequest.testInstance(challenge.getInvitationKey());
+
+		// when & then
+		assertThatThrownBy(() -> {
+			challengeService.inviteNewMemberWithInvitationKey(request, memberId);
+		}).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void 초대키를_통해서_챌린지의_간단한_정보를_가져온다() {
+		String name = "챌린지";
+		String description = "운동하는 챌린지.";
+		LocalDateTime startDateTime = LocalDateTime.of(2020, 9, 1, 0, 0);
+		LocalDateTime endDateTime = LocalDateTime.of(2030, 9, 1, 0, 0, 0);
+		CertifyType certifyType = CertifyType.PICTURE;
+
+		Challenge challenge = ChallengeCreator.create(name, description, startDateTime, endDateTime, certifyType);
+		challenge.addCreator(memberId);
+		challenge.createNewInvitationKey(memberId);
+		challengeRepository.save(challenge);
+
+		// when
+		ChallengeSimpleInfoResponse response = challengeService.getSimpleChallengeInfoByInvitationKey(challenge.getInvitationKey());
+
+		// then
+		assertThatChallengeSimpleInfoResponse(response, name, description, startDateTime, endDateTime, certifyType);
+	}
+
+	private void assertThatChallengeSimpleInfoResponse(ChallengeSimpleInfoResponse response, String name, String description, LocalDateTime startDateTime, LocalDateTime endDateTime, CertifyType certifyType) {
+		assertThat(response.getName()).isEqualTo(name);
+		assertThat(response.getDescription()).isEqualTo(description);
+		assertThat(response.getStartDateTime()).isEqualTo(startDateTime);
+		assertThat(response.getEndDateTime()).isEqualTo(endDateTime);
+		assertThat(response.getCertifyType()).isEqualTo(certifyType);
 	}
 
 	private void assertThatChallengeInfoResponse(ChallengeInfoResponse response, String name, String description, LocalDateTime startDateTime, LocalDateTime endDateTime, CertifyType certifyType) {

--- a/month-app/src/test/java/com/month/service/challenge/ChallengeServiceTest.java
+++ b/month-app/src/test/java/com/month/service/challenge/ChallengeServiceTest.java
@@ -1,0 +1,145 @@
+package com.month.service.challenge;
+
+import com.month.domain.challenge.*;
+import com.month.service.MemberSetupTest;
+import com.month.service.challenge.dto.request.ChallengeCreateRequest;
+import com.month.service.challenge.dto.request.ChallengeRetrieveRequest;
+import com.month.service.challenge.dto.response.ChallengeInfoResponse;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+class ChallengeServiceTest extends MemberSetupTest {
+
+	@Autowired
+	private ChallengeRepository challengeRepository;
+
+	@Autowired
+	private ChallengeMemberMapperRepository challengeMemberMapperRepository;
+
+	@Autowired
+	private ChallengeService challengeService;
+
+	@AfterEach
+	void cleanUp() {
+		super.cleanup();
+		challengeMemberMapperRepository.deleteAllInBatch();
+		challengeRepository.deleteAllInBatch();
+	}
+
+	@Test
+	void 새로운_챌린지를_생성한다() {
+		// given
+		String name = "운동합시다!";
+		String description = "매일 운동하는 챌린지.";
+		LocalDateTime startDateTime = LocalDateTime.of(2020, 9, 12, 0, 0);
+		LocalDateTime endDateTime = LocalDateTime.of(2020, 10, 12, 0, 0);
+		CertifyType certifyType = CertifyType.PICTURE;
+
+		ChallengeCreateRequest request = ChallengeCreateRequest.testBuilder()
+				.name(name)
+				.description(description)
+				.startDateTime(startDateTime)
+				.endDateTime(endDateTime)
+				.certifyType(certifyType)
+				.build();
+
+		// when
+		challengeService.createNewChallenge(request, memberId);
+
+		// then
+		List<Challenge> challenges = challengeRepository.findAll();
+		assertThat(challenges).hasSize(1);
+		assertThat(challenges.get(0).getUuid()).isNotNull();
+		assertThat(challenges.get(0).getMembersCount()).isEqualTo(1);
+		assertChallengeInfo(challenges.get(0), name, description, startDateTime, endDateTime, certifyType);
+	}
+
+	@Test
+	void 새로운_챌린지를_생성하면_자동으로_생성자가_된다() {
+		// given
+		String name = "운동합시다!";
+		String description = "매일 운동하는 챌린지.";
+		LocalDateTime startDateTime = LocalDateTime.of(2020, 9, 12, 0, 0);
+		LocalDateTime endDateTime = LocalDateTime.of(2020, 10, 12, 0, 0);
+		CertifyType certifyType = CertifyType.PICTURE;
+
+		ChallengeCreateRequest request = ChallengeCreateRequest.testBuilder()
+				.name(name)
+				.description(description)
+				.startDateTime(startDateTime)
+				.endDateTime(endDateTime)
+				.certifyType(certifyType)
+				.build();
+
+		// when
+		challengeService.createNewChallenge(request, memberId);
+
+		// then
+		List<ChallengeMemberMapper> challengeMemberMappers = challengeMemberMapperRepository.findAll();
+		assertThat(challengeMemberMappers).hasSize(1);
+		assertThat(challengeMemberMappers.get(0).getMemberId()).isEqualTo(memberId);
+		assertThat(challengeMemberMappers.get(0).getRole()).isEqualTo(ChallengeRole.CREATOR);
+	}
+
+	@Test
+	void 챌린지의_정보를_불러온다() {
+		// given
+		String name = "챌린지";
+		String description = "운동하는 챌린지";
+		LocalDateTime startDateTime = LocalDateTime.of(2020, 9, 1, 0, 0);
+		LocalDateTime endDateTime = LocalDateTime.of(2030, 9, 1, 0, 0, 0);
+		CertifyType certifyType = CertifyType.PICTURE;
+
+		Challenge challenge = ChallengeCreator.create(name, description, startDateTime, endDateTime, certifyType);
+		challenge.addCreator(memberId);
+		challengeRepository.save(challenge);
+
+		ChallengeRetrieveRequest request = ChallengeRetrieveRequest.testInstance(challenge.getUuid());
+
+		// when
+		ChallengeInfoResponse response = challengeService.getChallengeInfo(request, memberId);
+
+		// then
+		assertThatChallengeInfoResponse(response, name, description, startDateTime, endDateTime, certifyType);
+	}
+
+	@Test
+	void 챌린지에_참가하지_않은_멤버는_챌린지_정보를_불러올수_없다() {
+		// given
+		Challenge challenge = ChallengeCreator.create("챌린지");
+		challengeRepository.save(challenge);
+
+		ChallengeRetrieveRequest request = ChallengeRetrieveRequest.testInstance(challenge.getUuid());
+
+		// when & then
+		assertThatThrownBy(() -> {
+			ChallengeInfoResponse response = challengeService.getChallengeInfo(request, memberId);
+		}).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	private void assertThatChallengeInfoResponse(ChallengeInfoResponse response, String name, String description, LocalDateTime startDateTime, LocalDateTime endDateTime, CertifyType certifyType) {
+		assertThat(response.getName()).isEqualTo(name);
+		assertThat(response.getDescription()).isEqualTo(description);
+		assertThat(response.getStartDateTime()).isEqualTo(startDateTime);
+		assertThat(response.getEndDateTime()).isEqualTo(endDateTime);
+		assertThat(response.getCertifyType()).isEqualTo(certifyType);
+	}
+
+	private void assertChallengeInfo(Challenge challenge, String name, String description, LocalDateTime startDateTime, LocalDateTime endDateTime, CertifyType certifyType) {
+		assertThat(challenge.getName()).isEqualTo(name);
+		assertThat(challenge.getDescription()).isEqualTo(description);
+		assertThat(challenge.getStartDateTime()).isEqualTo(startDateTime);
+		assertThat(challenge.getEndDateTime()).isEqualTo(endDateTime);
+		assertThat(challenge.getCertifyType()).isEqualTo(certifyType);
+	}
+
+}

--- a/month-app/src/test/java/com/month/service/challenge/ChallengeServiceTest.java
+++ b/month-app/src/test/java/com/month/service/challenge/ChallengeServiceTest.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -122,8 +123,36 @@ class ChallengeServiceTest extends MemberSetupTest {
 
 		// when & then
 		assertThatThrownBy(() -> {
-			ChallengeInfoResponse response = challengeService.getChallengeInfo(request, memberId);
+			challengeService.getChallengeInfo(request, memberId);
 		}).isInstanceOf(IllegalArgumentException.class);
+	}
+
+	@Test
+	void 내가_참가하고_있는_모든_챌린지를_불러온다() {
+		// given
+		Challenge challenge1 = ChallengeCreator.create("챌린지1");
+		challenge1.addCreator(memberId);
+		Challenge challenge2 = ChallengeCreator.create("챌린지2");
+		challenge2.addParticipator(memberId);
+		challengeRepository.saveAll(Arrays.asList(challenge1, challenge2));
+
+		// when
+		List<ChallengeInfoResponse> responses = challengeService.getMyChallengeInfo(memberId);
+
+		// then
+		assertThat(responses).hasSize(2);
+		assertThat(responses.get(0).getName()).isEqualTo("챌린지1");
+		assertThat(responses.get(1).getName()).isEqualTo("챌린지2");
+	}
+
+	@Test
+	void 어떤_챌린지에도_참가하고_있지_않을때_나의_챌린지를_불러오면_빌_리스트가_반환된다() {
+		// when
+		List<ChallengeInfoResponse> responses = challengeService.getMyChallengeInfo(memberId);
+
+		// then
+		assertThat(responses).isEmpty();
+		assertThat(responses).isNotNull();
 	}
 
 	private void assertThatChallengeInfoResponse(ChallengeInfoResponse response, String name, String description, LocalDateTime startDateTime, LocalDateTime endDateTime, CertifyType certifyType) {

--- a/month-app/src/test/java/com/month/service/challenge/ChallengeServiceTest.java
+++ b/month-app/src/test/java/com/month/service/challenge/ChallengeServiceTest.java
@@ -2,6 +2,7 @@ package com.month.service.challenge;
 
 import com.month.domain.challenge.*;
 import com.month.service.MemberSetupTest;
+import com.month.service.challenge.dto.request.ChallengeCreateInvitationKeyRequest;
 import com.month.service.challenge.dto.request.ChallengeCreateRequest;
 import com.month.service.challenge.dto.request.ChallengeRetrieveRequest;
 import com.month.service.challenge.dto.response.ChallengeInfoResponse;
@@ -153,6 +154,24 @@ class ChallengeServiceTest extends MemberSetupTest {
 		// then
 		assertThat(responses).isEmpty();
 		assertThat(responses).isNotNull();
+	}
+
+	@Test
+	void 새로운_초대키를_발급한다() {
+		// given
+		Challenge challenge = ChallengeCreator.create("챌린지");
+		challenge.addCreator(memberId);
+		challengeRepository.save(challenge);
+
+		ChallengeCreateInvitationKeyRequest request = ChallengeCreateInvitationKeyRequest.testInstance(challenge.getUuid());
+
+		// when
+		challengeService.createInvitationKey(request, memberId);
+
+		// then
+		List<Challenge> challenges = challengeRepository.findAll();
+		assertThat(challenges).hasSize(1);
+		assertThat(challenges.get(0).getInvitationKey()).isNotNull();
 	}
 
 	private void assertThatChallengeInfoResponse(ChallengeInfoResponse response, String name, String description, LocalDateTime startDateTime, LocalDateTime endDateTime, CertifyType certifyType) {

--- a/month-common/build.gradle
+++ b/month-common/build.gradle
@@ -1,7 +1,0 @@
-bootJar { enabled = false }
-jar { enabled = true }
-
-
-dependencies {
-
-}

--- a/month-domain/build.gradle
+++ b/month-domain/build.gradle
@@ -17,8 +17,6 @@ buildscript {
 apply plugin: "com.ewerk.gradle.plugins.querydsl"
 
 dependencies {
-    implementation project(':month-common')
-
     api group: 'org.springframework.boot', name: 'spring-boot-starter-data-jpa', version: '2.2.8.RELEASE'
     runtimeOnly 'com.h2database:h2'
 

--- a/month-domain/src/main/java/com/month/domain/challenge/CertifyType.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/CertifyType.java
@@ -1,0 +1,7 @@
+package com.month.domain.challenge;
+
+public enum CertifyType {
+
+	PICTURE
+
+}

--- a/month-domain/src/main/java/com/month/domain/challenge/Challenge.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/Challenge.java
@@ -1,0 +1,103 @@
+package com.month.domain.challenge;
+
+import com.month.domain.common.DateTimeInterval;
+import com.month.domain.common.Uuid;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class Challenge {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Embedded
+	private Uuid uuid;
+
+	private String name;
+
+	private String description;
+
+	private int membersCount;
+
+	@Embedded
+	private DateTimeInterval dateTimeInterval;
+
+	@Embedded
+	private InvitationKey invitationKey;
+
+	@Enumerated(EnumType.STRING)
+	private CertifyType certifyType;
+
+	@OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<ChallengeMemberMapper> memberMappers = new ArrayList<>();
+
+	@Builder
+	private Challenge(String name, String description, LocalDateTime startDateTime, LocalDateTime endDateTime, CertifyType certifyType) {
+		this.uuid = Uuid.newInstance();
+		this.membersCount = 0;
+		this.dateTimeInterval = DateTimeInterval.of(startDateTime, endDateTime);
+		this.name = name;
+		this.description = description;
+		this.certifyType = certifyType;
+	}
+
+	public static Challenge of(String name, String description, LocalDateTime startDateTime, LocalDateTime endDateTime, CertifyType certifyType) {
+		return Challenge.builder()
+				.name(name)
+				.description(description)
+				.startDateTime(startDateTime)
+				.endDateTime(endDateTime)
+				.certifyType(certifyType)
+				.build();
+	}
+
+	public LocalDateTime getStartDateTime() {
+		return this.dateTimeInterval.getStartDateTime();
+	}
+
+	public LocalDateTime getEndDateTime() {
+		return this.dateTimeInterval.getEndDateTime();
+	}
+
+	public String getUuid() {
+		return this.uuid.getUuid();
+	}
+
+	public void addCreator(Long memberId) {
+		this.memberMappers.add(ChallengeMemberMapper.creator(this, memberId));
+		this.membersCount++;
+	}
+
+	public void addParticipator(Long memberId) {
+		this.memberMappers.add(ChallengeMemberMapper.participator(this, memberId));
+		this.membersCount++;
+	}
+
+	private boolean isCreator(Long memberId) {
+		return this.memberMappers.stream()
+				.anyMatch(memberMapper -> memberMapper.isCreator(memberId));
+	}
+
+	private boolean isParticipator(Long memberId) {
+		return this.memberMappers.stream()
+				.anyMatch(memberMapper -> memberMapper.isParticipator(memberId));
+	}
+
+	public void validateMemberInChallenge(Long memberId) {
+		if (!(isCreator(memberId) || isParticipator(memberId))) {
+			throw new IllegalArgumentException(String.format("멤버 (%s) 는 챌린지 (%s) 에 참가하고 있지 않습니다.", memberId, this.uuid));
+		}
+	}
+
+}

--- a/month-domain/src/main/java/com/month/domain/challenge/Challenge.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/Challenge.java
@@ -74,6 +74,14 @@ public class Challenge {
 		return this.uuid.getUuid();
 	}
 
+	public String getInvitationKey() {
+		return this.invitationKey.getInvitationKey();
+	}
+
+	public LocalDateTime getExpireDateTimeOfInvitationKey() {
+		return this.invitationKey.getExpireDateTime();
+	}
+
 	public void addCreator(Long memberId) {
 		this.memberMappers.add(ChallengeMemberMapper.creator(this, memberId));
 		this.membersCount++;
@@ -94,10 +102,21 @@ public class Challenge {
 				.anyMatch(memberMapper -> memberMapper.isParticipator(memberId));
 	}
 
+	private boolean isMemberInChallenge(Long memberId) {
+		return isCreator(memberId) || isParticipator(memberId);
+	}
+
 	public void validateMemberInChallenge(Long memberId) {
-		if (!(isCreator(memberId) || isParticipator(memberId))) {
+		if (!isMemberInChallenge(memberId)) {
 			throw new IllegalArgumentException(String.format("멤버 (%s) 는 챌린지 (%s) 에 참가하고 있지 않습니다.", memberId, this.uuid));
 		}
+	}
+
+	public void createNewInvitationKey(Long memberId) {
+		if (!isMemberInChallenge(memberId)) {
+			throw new IllegalArgumentException(String.format("챌린지 (%s) 에 참가하고 있는 멤버만이 초대키를 생성할 수 있습니다. 현재 멤버: %s", this.uuid, memberId));
+		}
+		this.invitationKey = InvitationKey.newInstance(getUuid(), memberId);
 	}
 
 }

--- a/month-domain/src/main/java/com/month/domain/challenge/ChallengeCreator.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/ChallengeCreator.java
@@ -1,0 +1,26 @@
+package com.month.domain.challenge;
+
+import java.time.LocalDateTime;
+
+public final class ChallengeCreator {
+
+	public static Challenge create(String name) {
+		return Challenge.builder()
+				.name(name)
+				.startDateTime(LocalDateTime.of(2020, 9, 1, 0, 0))
+				.endDateTime(LocalDateTime.of(2030, 9, 1, 0, 0))
+				.certifyType(CertifyType.PICTURE)
+				.build();
+	}
+
+	public static Challenge create(String name, String description, LocalDateTime startDateTime, LocalDateTime endDateTime, CertifyType certifyType) {
+		return Challenge.builder()
+				.name(name)
+				.description(description)
+				.startDateTime(startDateTime)
+				.endDateTime(endDateTime)
+				.certifyType(certifyType)
+				.build();
+	}
+
+}

--- a/month-domain/src/main/java/com/month/domain/challenge/ChallengeMemberMapper.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/ChallengeMemberMapper.java
@@ -1,0 +1,49 @@
+package com.month.domain.challenge;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+public class ChallengeMemberMapper {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "challenge_id")
+	private Challenge challenge;
+
+	private Long memberId;
+
+	@Enumerated(EnumType.STRING)
+	private ChallengeRole role;
+
+	private ChallengeMemberMapper(Challenge challenge, Long memberId, ChallengeRole role) {
+		this.challenge = challenge;
+		this.memberId = memberId;
+		this.role = role;
+	}
+
+	static ChallengeMemberMapper creator(Challenge challenge, Long memberId) {
+		return new ChallengeMemberMapper(challenge, memberId, ChallengeRole.CREATOR);
+	}
+
+	static ChallengeMemberMapper participator(Challenge challenge, Long memberId) {
+		return new ChallengeMemberMapper(challenge, memberId, ChallengeRole.PARTICIPATOR);
+	}
+
+	boolean isCreator(Long memberId) {
+		return this.memberId.equals(memberId) && this.role.equals(ChallengeRole.CREATOR);
+	}
+
+	boolean isParticipator(Long memberId) {
+		return this.memberId.equals(memberId) && this.role.equals(ChallengeRole.PARTICIPATOR);
+	}
+
+}

--- a/month-domain/src/main/java/com/month/domain/challenge/ChallengeMemberMapperRepository.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/ChallengeMemberMapperRepository.java
@@ -1,0 +1,10 @@
+package com.month.domain.challenge;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 테스트용도의 Repository
+ */
+public interface ChallengeMemberMapperRepository extends JpaRepository<ChallengeMemberMapper, Long> {
+
+}

--- a/month-domain/src/main/java/com/month/domain/challenge/ChallengeRepository.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/ChallengeRepository.java
@@ -1,0 +1,8 @@
+package com.month.domain.challenge;
+
+import com.month.domain.challenge.repository.ChallengeRepositoryCustom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ChallengeRepository extends JpaRepository<Challenge, Long>, ChallengeRepositoryCustom {
+
+}

--- a/month-domain/src/main/java/com/month/domain/challenge/ChallengeRole.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/ChallengeRole.java
@@ -1,0 +1,8 @@
+package com.month.domain.challenge;
+
+public enum ChallengeRole {
+
+	CREATOR,
+	PARTICIPATOR
+
+}

--- a/month-domain/src/main/java/com/month/domain/challenge/InvitationKey.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/InvitationKey.java
@@ -1,0 +1,16 @@
+package com.month.domain.challenge;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class InvitationKey {
+
+	// TODO 초대키 VO 생성
+
+}

--- a/month-domain/src/main/java/com/month/domain/challenge/InvitationKey.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/InvitationKey.java
@@ -5,12 +5,54 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Embeddable
 public class InvitationKey {
 
-	// TODO 초대키 VO 생성
+	private final static String DELIMITER = "-";
+	private final static int EXPIRE_DAY = 7;
+
+	private String invitationKey;
+
+	private LocalDateTime expireDateTime;
+
+	private InvitationKey(String invitationKey, LocalDateTime expireDateTime) {
+		this.invitationKey = invitationKey;
+		this.expireDateTime = expireDateTime;
+	}
+
+	static InvitationKey newInstance(String challengeUuid, Long memberId) {
+		return new InvitationKey(createInvitationKey(challengeUuid, memberId), calculateExpiresDateTime());
+	}
+
+	private static String createInvitationKey(String challengeUuid, Long memberId) {
+		return createIdentification() + DELIMITER + challengeUuid + DELIMITER + memberId;
+	}
+
+	private static LocalDateTime calculateExpiresDateTime() {
+		return LocalDateTime.now().plusDays(EXPIRE_DAY);
+	}
+
+	private static String createIdentification() {
+		return UUID.randomUUID().toString().substring(0, 5);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		InvitationKey that = (InvitationKey) o;
+		return Objects.equals(invitationKey, that.invitationKey);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(invitationKey);
+	}
 
 }

--- a/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -10,4 +10,6 @@ public interface ChallengeRepositoryCustom {
 
 	List<Challenge> findChallengesByMemberId(Long memberId);
 
+	Challenge findChallengeByInvitationKey(String invitationKey);
+
 }

--- a/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -2,8 +2,12 @@ package com.month.domain.challenge.repository;
 
 import com.month.domain.challenge.Challenge;
 
+import java.util.List;
+
 public interface ChallengeRepositoryCustom {
 
 	Challenge findChallengeByUuid(String uuid);
-	
+
+	List<Challenge> findChallengesByMemberId(Long memberId);
+
 }

--- a/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -1,0 +1,9 @@
+package com.month.domain.challenge.repository;
+
+import com.month.domain.challenge.Challenge;
+
+public interface ChallengeRepositoryCustom {
+
+	Challenge findChallengeByUuid(String uuid);
+	
+}

--- a/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
@@ -4,7 +4,10 @@ import com.month.domain.challenge.Challenge;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 import static com.month.domain.challenge.QChallenge.challenge;
+import static com.month.domain.challenge.QChallengeMemberMapper.challengeMemberMapper;
 
 @RequiredArgsConstructor
 public class ChallengeRepositoryCustomImpl implements ChallengeRepositoryCustom {
@@ -17,6 +20,15 @@ public class ChallengeRepositoryCustomImpl implements ChallengeRepositoryCustom 
 				.where(
 						challenge.uuid.uuid.eq(uuid)
 				).fetchOne();
+	}
+
+	@Override
+	public List<Challenge> findChallengesByMemberId(Long memberId) {
+		return queryFactory.selectFrom(challenge).distinct()
+				.innerJoin(challenge.memberMappers, challengeMemberMapper)
+				.where(
+						challengeMemberMapper.memberId.eq(memberId)
+				).fetch();
 	}
 
 }

--- a/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
@@ -1,0 +1,22 @@
+package com.month.domain.challenge.repository;
+
+import com.month.domain.challenge.Challenge;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static com.month.domain.challenge.QChallenge.challenge;
+
+@RequiredArgsConstructor
+public class ChallengeRepositoryCustomImpl implements ChallengeRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public Challenge findChallengeByUuid(String uuid) {
+		return queryFactory.selectFrom(challenge)
+				.where(
+						challenge.uuid.uuid.eq(uuid)
+				).fetchOne();
+	}
+
+}

--- a/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
@@ -16,7 +16,8 @@ public class ChallengeRepositoryCustomImpl implements ChallengeRepositoryCustom 
 
 	@Override
 	public Challenge findChallengeByUuid(String uuid) {
-		return queryFactory.selectFrom(challenge)
+		return queryFactory.selectFrom(challenge).distinct()
+				.innerJoin(challenge.memberMappers, challengeMemberMapper).fetchJoin()
 				.where(
 						challenge.uuid.uuid.eq(uuid)
 				).fetchOne();
@@ -25,10 +26,18 @@ public class ChallengeRepositoryCustomImpl implements ChallengeRepositoryCustom 
 	@Override
 	public List<Challenge> findChallengesByMemberId(Long memberId) {
 		return queryFactory.selectFrom(challenge).distinct()
-				.innerJoin(challenge.memberMappers, challengeMemberMapper)
+				.innerJoin(challenge.memberMappers, challengeMemberMapper).fetchJoin()
 				.where(
 						challengeMemberMapper.memberId.eq(memberId)
 				).fetch();
+	}
+
+	@Override
+	public Challenge findChallengeByInvitationKey(String invitationKey) {
+		return queryFactory.selectFrom(challenge)
+				.where(
+						challenge.invitationKey.invitationKey.eq(invitationKey)
+				).fetchOne();
 	}
 
 }

--- a/month-domain/src/main/java/com/month/domain/common/DateTimeInterval.java
+++ b/month-domain/src/main/java/com/month/domain/common/DateTimeInterval.java
@@ -1,0 +1,35 @@
+package com.month.domain.common;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Embeddable;
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class DateTimeInterval {
+
+	private LocalDateTime startDateTime;
+
+	private LocalDateTime endDateTime;
+
+	private DateTimeInterval(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+		this.startDateTime = startDateTime;
+		this.endDateTime = endDateTime;
+	}
+
+	public static DateTimeInterval of(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+		validateDateTime(startDateTime, endDateTime);
+		return new DateTimeInterval(startDateTime, endDateTime);
+	}
+
+	private static void validateDateTime(LocalDateTime startDateTime, LocalDateTime endDateTime) {
+		if (startDateTime.isAfter(endDateTime)) {
+			throw new IllegalArgumentException(String.format("종료시간 (%s)이 시작시간 (%s) 이전일 수 업습니다.", startDateTime, endDateTime));
+		}
+	}
+
+}

--- a/month-domain/src/main/java/com/month/domain/common/DateTimeInterval.java
+++ b/month-domain/src/main/java/com/month/domain/common/DateTimeInterval.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -30,6 +31,20 @@ public class DateTimeInterval {
 		if (startDateTime.isAfter(endDateTime)) {
 			throw new IllegalArgumentException(String.format("종료시간 (%s)이 시작시간 (%s) 이전일 수 업습니다.", startDateTime, endDateTime));
 		}
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		DateTimeInterval that = (DateTimeInterval) o;
+		return Objects.equals(startDateTime, that.startDateTime) &&
+				Objects.equals(endDateTime, that.endDateTime);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(startDateTime, endDateTime);
 	}
 
 }

--- a/month-domain/src/main/java/com/month/domain/common/Uuid.java
+++ b/month-domain/src/main/java/com/month/domain/common/Uuid.java
@@ -6,6 +6,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import java.util.Objects;
 import java.util.UUID;
 
 @Getter
@@ -28,6 +29,19 @@ public class Uuid {
 
 	public static Uuid of(String uuid) {
 		return new Uuid(uuid);
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Uuid uuid1 = (Uuid) o;
+		return Objects.equals(uuid, uuid1.uuid);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(uuid);
 	}
 
 }

--- a/month-domain/src/main/java/com/month/domain/common/Uuid.java
+++ b/month-domain/src/main/java/com/month/domain/common/Uuid.java
@@ -1,0 +1,33 @@
+package com.month.domain.common;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+import java.util.UUID;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Uuid {
+
+	private static final String version = "v1";
+
+	@Column(nullable = false)
+	private String uuid;
+
+	private Uuid(String uuid) {
+		this.uuid = uuid;
+	}
+
+	public static Uuid newInstance() {
+		return new Uuid(String.format("%s-%s", version, UUID.randomUUID()));
+	}
+
+	public static Uuid of(String uuid) {
+		return new Uuid(uuid);
+	}
+
+}

--- a/month-domain/src/main/java/com/month/domain/member/Member.java
+++ b/month-domain/src/main/java/com/month/domain/member/Member.java
@@ -1,6 +1,7 @@
 package com.month.domain.member;
 
 import com.month.domain.BaseTimeEntity;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,7 +10,7 @@ import org.springframework.util.StringUtils;
 import javax.persistence.*;
 
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Member extends BaseTimeEntity {
 

--- a/month-domain/src/main/java/com/month/domain/member/MemberCreator.java
+++ b/month-domain/src/main/java/com/month/domain/member/MemberCreator.java
@@ -2,6 +2,16 @@ package com.month.domain.member;
 
 public final class MemberCreator {
 
+	public static Member create(String email) {
+		return Member.builder()
+				.email(email)
+				.name("강승호")
+				.idToken("idToken")
+				.photoUrl("photoUrl")
+				.providerId("providerId")
+				.build();
+	}
+
 	public static Member create(String email, String name, String idToken) {
 		return Member.builder()
 				.email(email)

--- a/month-domain/src/main/java/com/month/domain/member/repository/MemberRepositoryCustom.java
+++ b/month-domain/src/main/java/com/month/domain/member/repository/MemberRepositoryCustom.java
@@ -2,10 +2,14 @@ package com.month.domain.member.repository;
 
 import com.month.domain.member.Member;
 
+import java.util.List;
+
 public interface MemberRepositoryCustom {
 
 	Member findMemberByTokenAndEmail(String idToken, String email);
 
 	Member findMemberId(Long memberId);
-	
+
+	List<Member> findMembersByMemberIds(List<Long> memberIds);
+
 }

--- a/month-domain/src/main/java/com/month/domain/member/repository/MemberRepositoryCustomImpl.java
+++ b/month-domain/src/main/java/com/month/domain/member/repository/MemberRepositoryCustomImpl.java
@@ -4,6 +4,8 @@ import com.month.domain.member.Member;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 
+import java.util.List;
+
 import static com.month.domain.member.QMember.member;
 
 @RequiredArgsConstructor
@@ -26,6 +28,14 @@ public class MemberRepositoryCustomImpl implements MemberRepositoryCustom {
 				.where(
 						member.id.eq(memberId)
 				).fetchOne();
+	}
+
+	@Override
+	public List<Member> findMembersByMemberIds(List<Long> memberIds) {
+		return queryFactory.selectFrom(member)
+				.where(
+						member.id.in(memberIds)
+				).fetch();
 	}
 
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,4 @@
 rootProject.name = 'month'
 include 'month-domain'
 include 'month-app'
-include 'month-common'
 


### PR DESCRIPTION
- 새로운 챌린지를 생성하는 API
- 특정 챌린지의 상세한 정보를 불러오는 API
- 내가 포함하고 있는 챌린지들의 리스트를 불러오는 API
- 챌린지의 새로운 초대키를 발급하는 API (현재 만료시간 = 7일)
- 발급된 초대키를 통해 챌린지에 참가하는 API
- 초대키를 통해 챌린지의 간단한 정보를 가져오는 API