### PR TITLE
도전 횟수 및 달성률 관련 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,8 @@
 def javaProjects = [
         project(':month-app'),
-        project(':month-domain'),
         project(':month-external'),
+        project(':month-domainservice'),
+        project(':month-domain'),
         project(':month-common')
 ]
 

--- a/month-app/build.gradle
+++ b/month-app/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     implementation project(':month-domain')
+    implementation project(':month-domainservice')
     implementation project(':month-external')
     implementation project(':month-common')
 

--- a/month-app/src/main/java/com/month/controller/friend/FriendMapperController.java
+++ b/month-app/src/main/java/com/month/controller/friend/FriendMapperController.java
@@ -3,10 +3,8 @@ package com.month.controller.friend;
 import com.month.config.resolver.LoginMember;
 import com.month.controller.ApiResponse;
 import com.month.service.friend.FriendMapperService;
-import com.month.service.friend.dto.request.CreateFriendMapperRequest;
-import com.month.service.friend.dto.request.DeleteFriendMapperRequest;
-import com.month.service.friend.dto.request.RetrieveFriendsInfoRequest;
-import com.month.service.friend.dto.request.UpdateFriendFavoriteRequest;
+import com.month.service.friend.dto.request.*;
+import com.month.service.friend.dto.response.FriendMemberDetailInfoResponse;
 import com.month.service.friend.dto.response.FriendMemberInfoResponse;
 import com.month.type.session.MemberSession;
 import io.swagger.annotations.ApiImplicitParam;
@@ -54,6 +52,11 @@ public class FriendMapperController {
 		return ApiResponse.OK;
 	}
 
-	// TODO 친구의 정보를 불러오는 API + (함께한 목표 정보들도 포함) - 아직 미정이라 차후 구현
+	@ApiOperation("친구의 상세정보를 조회하는 API")
+	@ApiImplicitParam(name = "Authorization", value = "Bearer Token", required = true, paramType = "header")
+	@GetMapping("/api/v1/member/friend")
+	public ApiResponse<FriendMemberDetailInfoResponse> retrieveFriendDetailInfo(@Valid RetrieveFriendDetailRequest request, @LoginMember MemberSession memberSession) {
+		return ApiResponse.of(friendMapperService.retrieveFriendDetailInfo(request, memberSession.getMemberId()));
+	}
 
 }

--- a/month-app/src/main/java/com/month/controller/member/MemberController.java
+++ b/month-app/src/main/java/com/month/controller/member/MemberController.java
@@ -4,6 +4,7 @@ import com.month.config.resolver.LoginMember;
 import com.month.controller.ApiResponse;
 import com.month.service.member.MemberService;
 import com.month.service.member.dto.request.MemberUpdateInfoRequest;
+import com.month.service.member.dto.response.MemberDetailInfoResponse;
 import com.month.service.member.dto.response.MemberInfoResponse;
 import com.month.type.session.MemberSession;
 import io.swagger.annotations.ApiImplicitParam;
@@ -25,7 +26,7 @@ public class MemberController {
 	@ApiOperation("자신의 회원 정보를 불러오는 API")
 	@ApiImplicitParam(name = "Authorization", value = "Bearer Token", required = true, paramType = "header")
 	@GetMapping("/api/v1/member")
-	public ApiResponse<MemberInfoResponse> getMemberInfo(@LoginMember MemberSession memberSession) {
+	public ApiResponse<MemberDetailInfoResponse> getMemberInfo(@LoginMember MemberSession memberSession) {
 		return ApiResponse.of(memberService.getMemberInfo(memberSession.getMemberId()));
 	}
 

--- a/month-app/src/main/java/com/month/service/friend/FriendMapperService.java
+++ b/month-app/src/main/java/com/month/service/friend/FriendMapperService.java
@@ -5,9 +5,12 @@ import com.month.domain.friend.FriendMapperCollection;
 import com.month.domain.member.Member;
 import com.month.domain.member.MemberRepository;
 import com.month.domain.friend.FriendMapperRepository;
+import com.month.domainservice.AchievementRateDomainService;
 import com.month.exception.NotAllowedException;
 import com.month.service.friend.dto.request.CreateFriendMapperRequest;
+import com.month.service.friend.dto.request.RetrieveFriendDetailRequest;
 import com.month.service.friend.dto.request.UpdateFriendFavoriteRequest;
+import com.month.service.friend.dto.response.FriendMemberDetailInfoResponse;
 import com.month.service.friend.dto.response.FriendMemberInfoResponse;
 import com.month.service.member.MemberServiceUtils;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +28,7 @@ public class FriendMapperService {
 
 	private final MemberRepository memberRepository;
 	private final FriendMapperRepository friendMapperRepository;
+	private final AchievementRateDomainService achievementRateDomainService;
 
 	@Transactional
 	public void createFriend(CreateFriendMapperRequest request, Long memberId) {
@@ -57,6 +61,15 @@ public class FriendMapperService {
 	public void deleteFriendMapper(Long friendMemberId, Long memberId) {
 		FriendMapper friendMapper = FriendMapperServiceUtils.findFriendMapper(friendMapperRepository, memberId, friendMemberId);
 		friendMapperRepository.delete(friendMapper);
+	}
+
+	@Transactional(readOnly = true)
+	public FriendMemberDetailInfoResponse retrieveFriendDetailInfo(RetrieveFriendDetailRequest request, Long memberId) {
+		Member friend = MemberServiceUtils.findMemberById(memberRepository, request.getFriendId());
+		return FriendMemberDetailInfoResponse.of(friend,
+				FriendMapperServiceUtils.findFriendMapper(friendMapperRepository, memberId, friend.getId()),
+				achievementRateDomainService.getChallengesCountWithFriend(memberId, friend.getId()),
+				achievementRateDomainService.getMemberAchievementRate(friend.getId()).getAchieveChallengeRate());
 	}
 
 }

--- a/month-app/src/main/java/com/month/service/friend/dto/request/RetrieveFriendDetailRequest.java
+++ b/month-app/src/main/java/com/month/service/friend/dto/request/RetrieveFriendDetailRequest.java
@@ -3,13 +3,16 @@ package com.month.service.friend.dto.request;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.NotNull;
+
 @Getter
 @NoArgsConstructor
 public class RetrieveFriendDetailRequest {
 
+	@NotNull
 	private Long friendId;
 
-	public RetrieveFriendDetailRequest(Long friendId) {
+	private RetrieveFriendDetailRequest(Long friendId) {
 		this.friendId = friendId;
 	}
 

--- a/month-app/src/main/java/com/month/service/friend/dto/request/RetrieveFriendDetailRequest.java
+++ b/month-app/src/main/java/com/month/service/friend/dto/request/RetrieveFriendDetailRequest.java
@@ -1,0 +1,20 @@
+package com.month.service.friend.dto.request;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RetrieveFriendDetailRequest {
+
+	private Long friendId;
+
+	public RetrieveFriendDetailRequest(Long friendId) {
+		this.friendId = friendId;
+	}
+
+	public static RetrieveFriendDetailRequest testInstance(Long friendId) {
+		return new RetrieveFriendDetailRequest(friendId);
+	}
+
+}

--- a/month-app/src/main/java/com/month/service/friend/dto/response/FriendMemberDetailInfoResponse.java
+++ b/month-app/src/main/java/com/month/service/friend/dto/response/FriendMemberDetailInfoResponse.java
@@ -1,0 +1,36 @@
+package com.month.service.friend.dto.response;
+
+import com.month.domain.friend.FriendMapper;
+import com.month.domain.member.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class FriendMemberDetailInfoResponse {
+
+	private final Long id;
+
+	private final String email;
+
+	private final String name;
+
+	private final String photoUrl;
+
+	private final boolean isFavorite;
+
+	private final int totalChallengesCountWithFriend;
+
+	private final double achieveChallengeRate;
+
+	public static FriendMemberDetailInfoResponse of(Member member, FriendMapper friendMapper,
+													int totalChallengesCountWithFriend, double achieveChallengeRate) {
+		return new FriendMemberDetailInfoResponse(member.getId(), member.getEmail(), member.getName(), member.getPhotoUrl(),
+				friendMapper.isFavorite(), totalChallengesCountWithFriend, achieveChallengeRate);
+	}
+
+}
+

--- a/month-app/src/main/java/com/month/service/member/MemberService.java
+++ b/month-app/src/main/java/com/month/service/member/MemberService.java
@@ -1,23 +1,35 @@
 package com.month.service.member;
 
+import com.month.domain.accreditation.Accreditation;
+import com.month.domain.accreditation.repository.AccreditationRepository;
+import com.month.domain.challenge.ChallengeCollection;
+import com.month.domain.challenge.ChallengeRepository;
 import com.month.domain.member.Member;
 import com.month.domain.member.MemberRepository;
 import com.month.service.member.dto.request.MemberUpdateInfoRequest;
+import com.month.service.member.dto.response.MemberDetailInfoResponse;
 import com.month.service.member.dto.response.MemberInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Service
 public class MemberService {
 
 	private final MemberRepository memberRepository;
+	private final ChallengeRepository challengeRepository;
+	private final AccreditationRepository accreditationRepository;
 
 	@Transactional(readOnly = true)
-	public MemberInfoResponse getMemberInfo(Long memberId) {
+	public MemberDetailInfoResponse getMemberInfo(Long memberId) {
 		Member member = MemberServiceUtils.findMemberById(memberRepository, memberId);
-		return MemberInfoResponse.of(member);
+		ChallengeCollection collection = ChallengeCollection.of(challengeRepository.findChallengesByMemberId(memberId));
+		List<Accreditation> accreditationList = accreditationRepository.findAllByChallengeUuidList(collection.getChallengesUuidList());
+		return MemberDetailInfoResponse.of(member, collection.getChallengesCount(),
+				collection.getAchieveRateOfChallenge(accreditationList.size()));
 	}
 
 	@Transactional

--- a/month-app/src/main/java/com/month/service/member/MemberService.java
+++ b/month-app/src/main/java/com/month/service/member/MemberService.java
@@ -1,11 +1,9 @@
 package com.month.service.member;
 
-import com.month.domain.accreditation.Accreditation;
-import com.month.domain.accreditation.repository.AccreditationRepository;
-import com.month.domain.challenge.ChallengeCollection;
-import com.month.domain.challenge.ChallengeRepository;
 import com.month.domain.member.Member;
 import com.month.domain.member.MemberRepository;
+import com.month.domainservice.AchievementRateDomainService;
+import com.month.domainservice.dto.response.MemberAchieveRateResponse;
 import com.month.service.member.dto.request.MemberUpdateInfoRequest;
 import com.month.service.member.dto.response.MemberDetailInfoResponse;
 import com.month.service.member.dto.response.MemberInfoResponse;
@@ -13,23 +11,18 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-
 @RequiredArgsConstructor
 @Service
 public class MemberService {
 
 	private final MemberRepository memberRepository;
-	private final ChallengeRepository challengeRepository;
-	private final AccreditationRepository accreditationRepository;
+	private final AchievementRateDomainService achievementRateDomainService;
 
 	@Transactional(readOnly = true)
 	public MemberDetailInfoResponse getMemberInfo(Long memberId) {
 		Member member = MemberServiceUtils.findMemberById(memberRepository, memberId);
-		ChallengeCollection collection = ChallengeCollection.of(challengeRepository.findChallengesByMemberId(memberId));
-		List<Accreditation> accreditationList = accreditationRepository.findAllByChallengeUuidList(collection.getChallengesUuidList());
-		return MemberDetailInfoResponse.of(member, collection.getChallengesCount(),
-				collection.getAchieveRateOfChallenge(accreditationList.size()));
+		MemberAchieveRateResponse achievementRate = achievementRateDomainService.getMemberAchievementRate(member.getId());
+		return MemberDetailInfoResponse.of(member, achievementRate.getTotalChallengesCount(), achievementRate.getAchieveChallengeRate());
 	}
 
 	@Transactional

--- a/month-app/src/main/java/com/month/service/member/dto/response/MemberDetailInfoResponse.java
+++ b/month-app/src/main/java/com/month/service/member/dto/response/MemberDetailInfoResponse.java
@@ -1,0 +1,29 @@
+package com.month.service.member.dto.response;
+
+import com.month.domain.member.Member;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberDetailInfoResponse {
+
+	private final Long id;
+
+	private final String email;
+
+	private final String name;
+
+	private final String photoUrl;
+
+	private final int totalChallengesCount;
+
+	private final double achieveChallengeRate;
+
+	public static MemberDetailInfoResponse of(Member member, int totalChallengesCount, double achieveRate) {
+		return new MemberDetailInfoResponse(member.getId(), member.getEmail(), member.getName(), member.getPhotoUrl(),
+				totalChallengesCount, achieveRate);
+	}
+
+}

--- a/month-app/src/test/java/com/month/service/member/MemberServiceTest.java
+++ b/month-app/src/test/java/com/month/service/member/MemberServiceTest.java
@@ -1,10 +1,16 @@
 package com.month.service.member;
 
+import com.month.domain.accreditation.Accreditation;
+import com.month.domain.accreditation.AccreditationCreator;
+import com.month.domain.accreditation.repository.AccreditationRepository;
+import com.month.domain.challenge.Challenge;
+import com.month.domain.challenge.ChallengeCreator;
+import com.month.domain.challenge.ChallengeRepository;
 import com.month.domain.member.Member;
 import com.month.domain.member.MemberCreator;
 import com.month.domain.member.MemberRepository;
 import com.month.service.member.dto.request.MemberUpdateInfoRequest;
-import com.month.service.member.dto.response.MemberInfoResponse;
+import com.month.service.member.dto.response.MemberDetailInfoResponse;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -14,6 +20,8 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.time.LocalDateTime;
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
@@ -28,11 +36,19 @@ class MemberServiceTest {
 	@Autowired
 	private MemberService memberService;
 
+	@Autowired
+	private ChallengeRepository challengeRepository;
+
+	@Autowired
+	private AccreditationRepository accreditationRepository;
+
 	private Member member;
 
 	@AfterEach
 	void cleanUp() {
 		memberRepository.deleteAll();
+		challengeRepository.deleteAll();
+		accreditationRepository.deleteAll();
 	}
 
 	@BeforeEach
@@ -48,10 +64,10 @@ class MemberServiceTest {
 		memberRepository.save(newMember);
 
 		// when
-		MemberInfoResponse response = memberService.getMemberInfo(newMember.getId());
+		MemberDetailInfoResponse response = memberService.getMemberInfo(newMember.getId());
 
 		// then
-		assertThatMemberInfoResponse(response, newMember.getId(), email, name, photoUrl);
+		assertThatMemberDetailInfoResponse(response, newMember.getId(), email, name, photoUrl);
 	}
 
 	private static Stream<Arguments> sources_load_my_profile() {
@@ -59,6 +75,68 @@ class MemberServiceTest {
 				Arguments.of("will.seungho@gmail.com", "강승호", "https://photoUrl.com", "seungho-uid"),
 				Arguments.of("ksh980212@gmail.com", "will", "http://picture.com", "will-uid")
 		);
+	}
+
+	@Test
+	void 내가_도전한_횟수를_가져온다() {
+		// given
+		Member member = MemberCreator.create("will.seungho@gmail.com");
+		memberRepository.save(member);
+
+		Challenge challenge1 = ChallengeCreator.create("챌린지1",
+				LocalDateTime.of(2020, 10, 14, 0, 0),
+				LocalDateTime.of(2020, 11, 14, 0, 0));
+		challenge1.addCreator(member.getId());
+
+		Challenge challenge2 = ChallengeCreator.create("챌린지2",
+				LocalDateTime.of(2020, 10, 14, 0, 0),
+				LocalDateTime.of(2020, 11, 14, 0, 0));
+		challenge2.addParticipator(member.getId());
+
+		challengeRepository.saveAll(Arrays.asList(challenge1, challenge2));
+
+		// when
+		MemberDetailInfoResponse response = memberService.getMemberInfo(member.getId());
+
+		// then
+		assertThat(response.getTotalChallengesCount()).isEqualTo(2);
+	}
+
+	@Test
+	void 나의_정보를_반환할때_나의_달성_퍼센트를_계산해서_같이_반환한다() {
+		// given
+		Member member = MemberCreator.create("will.seungho@gmail.com");
+		memberRepository.save(member);
+
+		Challenge challenge = ChallengeCreator.create("챌린지1",
+				LocalDateTime.of(2019, 10, 14, 0, 0),
+				LocalDateTime.of(2019, 10, 22, 0, 0));
+		challenge.addCreator(member.getId());
+		challengeRepository.save(challenge);
+
+		Accreditation accreditation1 = AccreditationCreator.create(member.getId(), challenge.getUuid());
+		Accreditation accreditation2 = AccreditationCreator.create(member.getId(), challenge.getUuid());
+		accreditationRepository.saveAll(Arrays.asList(accreditation1, accreditation2));
+
+		// when
+		MemberDetailInfoResponse response = memberService.getMemberInfo(member.getId());
+
+		// then
+		assertThat(response.getAchieveChallengeRate()).isEqualTo(25.0);
+	}
+
+	@Test
+	void 어떤_챌린지도_하지않은경우_총_도전수_0_되고_달성률_0_가된다() {
+		// given
+		Member member = MemberCreator.create("will.seungho@gmail.com");
+		memberRepository.save(member);
+
+		// when
+		MemberDetailInfoResponse response = memberService.getMemberInfo(member.getId());
+
+		// then
+		assertThat(response.getTotalChallengesCount()).isEqualTo(0);
+		assertThat(response.getAchieveChallengeRate()).isEqualTo(0);
 	}
 
 	@Test
@@ -80,7 +158,7 @@ class MemberServiceTest {
 		assertThatMemberInfo(members.get(0), member.getEmail(), name, photoUrl, member.getUid());
 	}
 
-	private void assertThatMemberInfoResponse(MemberInfoResponse response, Long id, String email, String name, String photoUrl) {
+	private void assertThatMemberDetailInfoResponse(MemberDetailInfoResponse response, Long id, String email, String name, String photoUrl) {
 		assertThat(response.getId()).isEqualTo(id);
 		assertThat(response.getEmail()).isEqualTo(email);
 		assertThat(response.getName()).isEqualTo(name);

--- a/month-domain/src/main/java/com/month/domain/accreditation/AccreditationCreator.java
+++ b/month-domain/src/main/java/com/month/domain/accreditation/AccreditationCreator.java
@@ -1,0 +1,19 @@
+
+package com.month.domain.accreditation;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class AccreditationCreator {
+
+	public static Accreditation create(Long memberId, String challengeUuid) {
+		return Accreditation.builder()
+				.memo("인증완료!")
+				.image("imageUrl")
+				.memberId(memberId)
+				.uuid(challengeUuid)
+				.build();
+	}
+
+}

--- a/month-domain/src/main/java/com/month/domain/accreditation/repository/AccreditationRepository.java
+++ b/month-domain/src/main/java/com/month/domain/accreditation/repository/AccreditationRepository.java
@@ -2,10 +2,12 @@ package com.month.domain.accreditation.repository;
 
 import com.month.domain.accreditation.Accreditation;
 import org.springframework.data.jpa.repository.JpaRepository;
+
 import java.time.LocalDate;
 import java.util.List;
 
-public interface AccreditationRepository extends JpaRepository<Accreditation, Long> {
-    List<Accreditation> findAllByChallengeUuidAndDate(String challengeUuid, LocalDate date);
-    Accreditation findByChallengeUuidAndDateAndMemberId(String challengeUuid, LocalDate date, Long memberId);
+public interface AccreditationRepository extends JpaRepository<Accreditation, Long>, AccreditationRepositoryCustom {
+	List<Accreditation> findAllByChallengeUuidAndDate(String challengeUuid, LocalDate date);
+
+	Accreditation findByChallengeUuidAndDateAndMemberId(String challengeUuid, LocalDate date, Long memberId);
 }

--- a/month-domain/src/main/java/com/month/domain/accreditation/repository/AccreditationRepositoryCustom.java
+++ b/month-domain/src/main/java/com/month/domain/accreditation/repository/AccreditationRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.month.domain.accreditation.repository;
+
+import com.month.domain.accreditation.Accreditation;
+
+import java.util.List;
+
+public interface AccreditationRepositoryCustom {
+
+	List<Accreditation> findAllByChallengeUuidList(List<String> challengesUuidList);
+
+}

--- a/month-domain/src/main/java/com/month/domain/accreditation/repository/AccreditationRepositoryCustomImpl.java
+++ b/month-domain/src/main/java/com/month/domain/accreditation/repository/AccreditationRepositoryCustomImpl.java
@@ -1,0 +1,24 @@
+package com.month.domain.accreditation.repository;
+
+import com.month.domain.accreditation.Accreditation;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+import static com.month.domain.accreditation.QAccreditation.accreditation;
+
+@RequiredArgsConstructor
+public class AccreditationRepositoryCustomImpl implements AccreditationRepositoryCustom {
+
+	private final JPAQueryFactory queryFactory;
+
+	@Override
+	public List<Accreditation> findAllByChallengeUuidList(List<String> challengesUuidList) {
+		return queryFactory.selectFrom(accreditation)
+				.where(
+						accreditation.challengeUuid.in(challengesUuidList)
+				).fetch();
+	}
+
+}

--- a/month-domain/src/main/java/com/month/domain/challenge/Challenge.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/Challenge.java
@@ -119,6 +119,20 @@ public class Challenge extends BaseTimeEntity {
 		this.membersCount++;
 	}
 
+	private boolean isCreator(Long memberId) {
+		return challengeMemberMappers.stream()
+				.anyMatch(challengeMemberMapper -> challengeMemberMapper.isCreator(memberId));
+	}
+
+	private boolean isParticipator(Long memberId) {
+		return challengeMemberMappers.stream()
+				.anyMatch(challengeMemberMapper -> challengeMemberMapper.isParticipator(memberId));
+	}
+
+	public boolean isMemberInChallenge(Long memberId) {
+		return isCreator(memberId) || isParticipator(memberId);
+	}
+
 	public List<Long> getMemberIds() {
 		return this.challengeMemberMappers.stream()
 				.map(ChallengeMemberMapper::getMemberId)

--- a/month-domain/src/main/java/com/month/domain/challenge/Challenge.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/Challenge.java
@@ -15,7 +15,9 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -56,6 +58,30 @@ public class Challenge extends BaseTimeEntity {
 
 	public LocalDateTime getEndDateTime() {
 		return this.dateTimeInterval.getEndDateTime();
+	}
+
+	int calculateProgressDays() {
+		final LocalDateTime now = LocalDateTime.now();
+		// 이미 끝난 챌린지의 경우에는 startDateTime ~ endDateTime
+		if (isFinishChallenge(now)) {
+			Period period = Period.between(getStartDate(), getEndDate());
+			return period.getDays();
+		}
+		// 현재 진행중인 챌린지의 경우에는 startDateTime ~ now
+		Period period = Period.between(getStartDate(), now.toLocalDate());
+		return period.getDays();
+	}
+
+	boolean isFinishChallenge(LocalDateTime datetime) {
+		return this.getEndDateTime().isBefore(datetime);
+	}
+
+	private LocalDate getStartDate() {
+		return getStartDateTime().toLocalDate();
+	}
+
+	private LocalDate getEndDate() {
+		return getEndDateTime().toLocalDate();
 	}
 
 	@Builder

--- a/month-domain/src/main/java/com/month/domain/challenge/ChallengeCollection.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/ChallengeCollection.java
@@ -1,0 +1,48 @@
+package com.month.domain.challenge;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class ChallengeCollection {
+
+	private final List<Challenge> challengeList = new ArrayList<>();
+
+	private ChallengeCollection(List<Challenge> challengeList) {
+		this.challengeList.addAll(challengeList);
+	}
+
+	public static ChallengeCollection of(List<Challenge> challenges) {
+		return new ChallengeCollection(challenges);
+	}
+
+	public List<String> getChallengesUuidList() {
+		return challengeList.stream()
+				.map(Challenge::getUuid)
+				.collect(Collectors.toList());
+	}
+
+	public int getChallengesCount() {
+		return challengeList.size();
+	}
+
+	public double getAchieveRateOfChallenge(int achieveCount) {
+		int totalChallengeDays = getTotalChallengeDays();
+		if (totalChallengeDays == 0) {
+			return 0;
+		}
+		double percent = (double) (achieveCount) / totalChallengeDays * 100;
+		return Math.round(percent);
+	}
+
+	private int getTotalChallengeDays() {
+		return challengeList.stream()
+				.mapToInt(Challenge::calculateProgressDays)
+				.sum();
+	}
+
+}

--- a/month-domain/src/main/java/com/month/domain/challenge/ChallengeMemberMapper.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/ChallengeMemberMapper.java
@@ -49,4 +49,12 @@ public class ChallengeMemberMapper extends BaseTimeEntity {
 		return new ChallengeMemberMapper(challenge, memberId, ChallengeRole.PARTICIPATOR);
 	}
 
+	boolean isCreator(Long memberId) {
+		return this.memberId.equals(memberId) && this.role.equals(ChallengeRole.CREATOR);
+	}
+
+	boolean isParticipator(Long memberId) {
+		return this.memberId.equals(memberId) && this.role.equals(ChallengeRole.PARTICIPATOR);
+	}
+
 }

--- a/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -8,4 +8,6 @@ public interface ChallengeRepositoryCustom {
 
 	List<Challenge> findActiveChallengesByMemberId(Long memberId);
 
+	List<Challenge> findChallengesByMemberId(Long memberId);
+
 }

--- a/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -10,4 +10,6 @@ public interface ChallengeRepositoryCustom {
 
 	List<Challenge> findChallengesByMemberId(Long memberId);
 
+	List<Challenge> findNoFetchChallengesByMemberId(Long memberId);
+
 }

--- a/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
@@ -26,4 +26,13 @@ public class ChallengeRepositoryCustomImpl implements ChallengeRepositoryCustom 
 				).fetch();
 	}
 
+	@Override
+	public List<Challenge> findChallengesByMemberId(Long memberId) {
+		return queryFactory.selectFrom(challenge).distinct()
+				.innerJoin(challenge.challengeMemberMappers, challengeMemberMapper).fetchJoin()
+				.where(
+						challengeMemberMapper.memberId.eq(memberId)
+				).fetch();
+	}
+
 }

--- a/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
+++ b/month-domain/src/main/java/com/month/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
@@ -35,4 +35,23 @@ public class ChallengeRepositoryCustomImpl implements ChallengeRepositoryCustom 
 				).fetch();
 	}
 
+
+	/**
+	 * Challenge A  -  ChallengeMemberMapper1 (나) -> 페치 조인시 애만 조회 되는 상황
+	 * Challenge A  -  ChallengeMemberMapper2 (친구) -> 애가 조회 안되는 상황
+	 * <p>
+	 * 지금처럼 비즈니스 로직 단에서 필터링 하는 방법보다
+	 * 쿼리 조회	시, membrerId (1, 2, 3)리스트가 주어졌을때,
+	 * 1, 2, 3 모두 ChallengeMemberMapper가 있는 Challenge 리스트를 조회하는 방법?
+	 */
+	// TODO: 방법이 당장 생각 안나서 임시로 페치조인 푼 메소드 하나 추가해서 사용하고 있는데 개선이 필요합니다.
+	@Override
+	public List<Challenge> findNoFetchChallengesByMemberId(Long memberId) {
+		return queryFactory.selectFrom(challenge).distinct()
+				.innerJoin(challenge.challengeMemberMappers, challengeMemberMapper)
+				.where(
+						challengeMemberMapper.memberId.eq(memberId)
+				).fetch();
+	}
+
 }

--- a/month-domain/src/main/java/com/month/domain/friend/FriendMapperCollection.java
+++ b/month-domain/src/main/java/com/month/domain/friend/FriendMapperCollection.java
@@ -12,9 +12,9 @@ import java.util.stream.Collectors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class FriendMapperCollection {
 
-	private List<FriendMapper> friendMapperList = new ArrayList<>();
+	private final List<FriendMapper> friendMapperList = new ArrayList<>();
 
-	private Map<Long, FriendMapper> friendMapperMap = new HashMap<>();
+	private final Map<Long, FriendMapper> friendMapperMap = new HashMap<>();
 
 	private FriendMapperCollection(List<FriendMapper> friendMapperList) {
 		this.friendMapperList.addAll(friendMapperList);

--- a/month-domain/src/test/java/com/month/domain/accreditation/AccreditationRepositoryTest.java
+++ b/month-domain/src/test/java/com/month/domain/accreditation/AccreditationRepositoryTest.java
@@ -1,0 +1,34 @@
+package com.month.domain.accreditation;
+
+import com.month.domain.accreditation.repository.AccreditationRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+class AccreditationRepositoryTest {
+
+	@Autowired
+	private AccreditationRepository accreditationRepository;
+
+	@Test
+	void test_findAllByChallengeUuid() {
+		// given
+		Accreditation accreditation1 = AccreditationCreator.create(1L, "uuid1");
+		Accreditation accreditation2 = AccreditationCreator.create(1L, "uuid2");
+		accreditationRepository.saveAll(Arrays.asList(accreditation1, accreditation2));
+
+		// when
+		List<String> uuidList = Arrays.asList(accreditation1.getChallengeUuid(), accreditation2.getChallengeUuid());
+		List<Accreditation> accreditationList = accreditationRepository.findAllByChallengeUuidList(uuidList);
+
+		// then
+		assertThat(accreditationList).hasSize(2);
+	}
+
+}

--- a/month-domainservice/build.gradle
+++ b/month-domainservice/build.gradle
@@ -1,0 +1,7 @@
+bootJar { enabled = false }
+jar { enabled = true }
+
+dependencies {
+    implementation project(':month-domain')
+    implementation project(':month-common')
+}

--- a/month-domainservice/src/main/java/com/month/domainservice/AchievementRateDomainService.java
+++ b/month-domainservice/src/main/java/com/month/domainservice/AchievementRateDomainService.java
@@ -2,6 +2,7 @@ package com.month.domainservice;
 
 import com.month.domain.accreditation.Accreditation;
 import com.month.domain.accreditation.repository.AccreditationRepository;
+import com.month.domain.challenge.Challenge;
 import com.month.domain.challenge.ChallengeCollection;
 import com.month.domain.challenge.ChallengeRepository;
 import com.month.domainservice.dto.response.MemberAchieveRateResponse;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -23,6 +25,15 @@ public class AchievementRateDomainService {
 		ChallengeCollection collection = ChallengeCollection.of(challengeRepository.findChallengesByMemberId(memberId));
 		List<Accreditation> accreditationList = accreditationRepository.findAllByChallengeUuidList(collection.getChallengesUuidList());
 		return MemberAchieveRateResponse.of(collection.getChallengesCount(), collection.getAchieveRateOfChallenge(accreditationList.size()));
+	}
+
+	@Transactional(readOnly = true)
+	public int getChallengesCountWithFriend(Long memberId, Long friendId) {
+		List<Challenge> challenges = challengeRepository.findNoFetchChallengesByMemberId(memberId);
+		List<Challenge> challengesWithFriend = challenges.stream()
+				.filter(challenge -> challenge.isMemberInChallenge(friendId))
+				.collect(Collectors.toList());
+		return challengesWithFriend.size();
 	}
 
 }

--- a/month-domainservice/src/main/java/com/month/domainservice/AchievementRateDomainService.java
+++ b/month-domainservice/src/main/java/com/month/domainservice/AchievementRateDomainService.java
@@ -1,0 +1,28 @@
+package com.month.domainservice;
+
+import com.month.domain.accreditation.Accreditation;
+import com.month.domain.accreditation.repository.AccreditationRepository;
+import com.month.domain.challenge.ChallengeCollection;
+import com.month.domain.challenge.ChallengeRepository;
+import com.month.domainservice.dto.response.MemberAchieveRateResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class AchievementRateDomainService {
+
+	private final ChallengeRepository challengeRepository;
+	private final AccreditationRepository accreditationRepository;
+
+	@Transactional(readOnly = true)
+	public MemberAchieveRateResponse getMemberAchievementRate(Long memberId) {
+		ChallengeCollection collection = ChallengeCollection.of(challengeRepository.findChallengesByMemberId(memberId));
+		List<Accreditation> accreditationList = accreditationRepository.findAllByChallengeUuidList(collection.getChallengesUuidList());
+		return MemberAchieveRateResponse.of(collection.getChallengesCount(), collection.getAchieveRateOfChallenge(accreditationList.size()));
+	}
+
+}

--- a/month-domainservice/src/main/java/com/month/domainservice/dto/response/MemberAchieveRateResponse.java
+++ b/month-domainservice/src/main/java/com/month/domainservice/dto/response/MemberAchieveRateResponse.java
@@ -1,0 +1,19 @@
+package com.month.domainservice.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberAchieveRateResponse {
+
+	private final int totalChallengesCount;
+
+	private final double achieveChallengeRate;
+
+	public static MemberAchieveRateResponse of(int totalChallengesCount, double achieveChallengeRate) {
+		return new MemberAchieveRateResponse(totalChallengesCount, achieveChallengeRate);
+	}
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -3,4 +3,5 @@ include 'month-domain'
 include 'month-app'
 include 'month-external'
 include 'month-common'
+include 'month-domainservice'
 


### PR DESCRIPTION
## 기능 추가
- 내 정보를 불러올때, 지금까지 참가한 도전의 수 및 도전에 대한 달성률을 조회하는 기능 포함
- 친구의 정보를 불러올 때, 친구와 함께한 도전의 수 및 친구의 달성률을 조회하는 기능 포함.

> 친구와 함께 도전한 챌린지의 수 로직 쪽 개선 필요합니다.
> ChallengeRepositoryCustomImpl ~ AchievementRateDomainService